### PR TITLE
allow secrets to be passed as parameter

### DIFF
--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -29,11 +29,11 @@ import requests
 
 try:
     import board
-    _display_arg_required = False
+
+    DISPLAY_ARG_REQUIRED = False
 except NotImplementedError:
     # okay to run Generic Linux
-    _display_arg_required = True
-    pass
+    DISPLAY_ARG_REQUIRED = True
 import digitalio
 import displayio
 import wget as wget_lib
@@ -182,8 +182,10 @@ class PyPortal:
         spi = None
 
         if self.display is None:
-            if _display_arg_required:
-                raise RuntimeError("Display must be provided on platforms without board.")
+            if DISPLAY_ARG_REQUIRED:
+                raise RuntimeError(
+                    "Display must be provided on platforms without board."
+                )
             if external_spi:  # If SPI Object Passed
                 spi = external_spi
             else:  # Else: Make ESP32 connection

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -125,6 +125,7 @@ class PyPortal:
     :param debug: Turn on debug print outs. Defaults to False.
     :param display: The displayio display object to use
     :param touchscreen: The touchscreen object to use. Usually STMPE610 or FocalTouch.
+    :param secrets: The secrets object to use. If not supplied we will attempt to import.
 
     """
 

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -26,6 +26,7 @@ import time
 import gc
 import subprocess
 import requests
+
 try:
     import board
 except NotImplementedError:
@@ -162,6 +163,7 @@ class PyPortal:
     ):
 
         if not secrets:
+            # pylint: disable=import-outside-toplevel
             try:
                 from secrets import secrets  # pylint: disable=no-name-in-module
             except RuntimeError:
@@ -580,14 +582,13 @@ class PyPortal:
 
     # pylint: enable=no-self-use
 
-    @staticmethod
-    def image_converter_url(image_url, width, height, color_depth=16):
+    def image_converter_url(self, image_url, width, height, color_depth=16):
         """Generate a converted image url from the url passed in,
            with the given width and height. aio_username and aio_key must be
            set in secrets."""
         try:
-            aio_username = secrets["aio_username"]
-            aio_key = secrets["aio_key"]
+            aio_username = self.secrets["aio_username"]
+            aio_key = self.secrets["aio_key"]
         except KeyError:
             raise KeyError(
                 "\n\nOur image converter service require a login/password to rate-limit. Please register for a free adafruit.io account and place the user/key in your secrets file under 'aio_username' and 'aio_key'"  # pylint: disable=line-too-long

--- a/adafruit_pyportal.py
+++ b/adafruit_pyportal.py
@@ -29,8 +29,10 @@ import requests
 
 try:
     import board
+    _display_arg_required = False
 except NotImplementedError:
     # okay to run Generic Linux
+    _display_arg_required = True
     pass
 import digitalio
 import displayio
@@ -180,6 +182,8 @@ class PyPortal:
         spi = None
 
         if self.display is None:
+            if _display_arg_required:
+                raise RuntimeError("Display must be provided on platforms without board.")
             if external_spi:  # If SPI Object Passed
                 spi = external_spi
             else:  # Else: Make ESP32 connection


### PR DESCRIPTION
I've started work on allowing secrets to get passed as a constructor parameter as noted in #16. I also caught the error from failing to import `board` this allows the code to continue working on Generic Linux and other platforms that are not supported by Blinka, but still supported by Blinka_Displayio.

I'm leaving this as a draft for now. There is still work that needs to be done on the docstring. Something will need to be done with `image_converter_url()` function as well. It's currently static which means it doesn't have access to `self` which is where I started trying to keep the secrets dict. It will either need to be made non-static, or else maybe it can accept secrets as a parameter.  